### PR TITLE
fix: mutation observer should record the prev value of a changed attribute

### DIFF
--- a/src/element/element.ts
+++ b/src/element/element.ts
@@ -93,6 +93,7 @@ export abstract class Element extends HTMLElement {
 
     this._attributeObserver.observe(this, {
       attributeFilter: this._observedAttributes,
+      attributeOldValue: true,
       attributes: true,
       childList: false,
       subtree: false,


### PR DESCRIPTION
Fixed a misconfigured MutationObserver, it was not recording old attribute values and as a result `prevValue` property in the `ElementAttributeDidChangeEvent` events details were always unpopulated.