### PR TITLE
feat: added support for top-level jsx fragments

### DIFF
--- a/src/element/element-events.ts
+++ b/src/element/element-events.ts
@@ -22,13 +22,11 @@ export class ElementDidUpdateEvent extends CustomEvent<undefined> {
   }
 }
 
-export class ElementDidMountEvent extends CustomEvent<
-  HTMLElement | Text
-> {
+export class ElementDidMountEvent extends CustomEvent<undefined> {
   declare type: ElementLifecycleEvent.DidMount;
 
-  constructor(elem: HTMLElement | Text) {
-    super(ElementLifecycleEvent.DidMount, { detail: elem });
+  constructor() {
+    super(ElementLifecycleEvent.DidMount);
   }
 }
 

--- a/src/vdom/virtual-element.ts
+++ b/src/vdom/virtual-element.ts
@@ -25,6 +25,21 @@ export class VirtualElement {
     }
   }
 
+  static createFor(name: string, element: HTMLElement) {
+    const instance = Object.setPrototypeOf(
+      {
+        elementName: name,
+        element: element,
+        lastUpdatedAttributes: [],
+        children: [],
+        attributes: new ArrayMap(),
+      },
+      VirtualElement.prototype,
+    );
+
+    return instance;
+  }
+
   public readonly elementName: ElementName;
   public readonly element: HTMLElement;
 
@@ -54,7 +69,7 @@ export class VirtualElement {
     setter(attr[1]);
   }
 
-  private updateAttributes(attributes: JsonAttribute[]): void {
+  public updateAttributes(attributes: JsonAttribute[]): void {
     const updatedAttributes: string[] = [];
 
     for (let i = 0; i < attributes.length; i++) {
@@ -82,7 +97,7 @@ export class VirtualElement {
     this.lastUpdatedAttributes = updatedAttributes;
   }
 
-  private updateChildren(children: Array<JsxteJson | string>): void {
+  public updateChildren(children: Array<JsxteJson | string>): void {
     children = expandFragments(children);
 
     if (this.children.length > children.length) {
@@ -129,6 +144,17 @@ export class VirtualElement {
         }
       }
     }
+  }
+
+  public getChildElements(): Array<HTMLElement | Text> {
+    const result: Array<HTMLElement | Text> = [];
+
+    for (let i = 0; i < this.children.length; i++) {
+      const child = this.children[i]!;
+      result.push(child.element);
+    }
+
+    return result;
   }
 
   public update(elemJson: JsxteJson): void {


### PR DESCRIPTION
Previously if a JSX fragment was returned from the `render()` function it would not work - rendering would fail with an error. This fixes that and allows for rendering multiple child elements on the top level of the component.

**Example**
This is now ok:
```tsx
render() {
 return <>
    <div>1</div>
    <div>2</div>
  </>
}
```
The resulting html will look like this:
```html
<my-component>
  <div>1</div>
  <div>2</div>
</my-component>
```