### PR TITLE
feat: a custom setter function for attributes of name `value`

### DIFF
--- a/src/vdom/attribute-setter.ts
+++ b/src/vdom/attribute-setter.ts
@@ -21,6 +21,21 @@ export function attributeSetterFactory(
 
       lastValue = value;
     };
+  } else if (attr === "value" && "value" in element) {
+    let lastValue: string | undefined = attr[1];
+
+    return (value: any): void => {
+      if (value === lastValue) return;
+
+      lastValue = value;
+      if (value == null || value === false) {
+        element.removeAttribute(attr);
+        element.value = "";
+      } else {
+        element.setAttribute(attr, value);
+        element.value = value;
+      }
+    };
   } else {
     let lastValue: string | undefined = attr[1];
 


### PR DESCRIPTION
Added a special case for `value` attribute. If this attribute is encountered, aside from the attribute the `Element.value` property will also be set. This is mainly to address the `<input>` element which does not update it's contents when the attribute alone is changed.