### PR TITLE
feat: added an `effect` and `immediateEffect` methods to the Element class

### DIFF
--- a/src/element/element.ts
+++ b/src/element/element.ts
@@ -5,9 +5,16 @@ import {
   ElementAttributeDidChangeEvent,
   ElementDidMountEvent,
   ElementDidUpdateEvent,
+  ElementLifecycleEvent,
+  ElementStateDidChangeEvent,
   ElementWillUpdateEvent,
 } from "./element-events";
 import { RequestBatch } from "./request-batch";
+
+export type Dependency<T> = {
+  getValue: () => T;
+  name: string;
+};
 
 export abstract class Element extends HTMLElement {
   private _vroot?: VirtualElement;
@@ -18,6 +25,18 @@ export abstract class Element extends HTMLElement {
   );
   private _observedAttributes: string[] = [];
   private _isConnected = false;
+
+  private _dependencySelector = new Proxy(
+    {},
+    {
+      get: (_, prop) => {
+        return {
+          getValue: () => (this as any)[prop],
+          name: prop as string,
+        };
+      },
+    },
+  ) as any;
 
   public lifecycle = new EventEmitter();
 
@@ -31,7 +50,9 @@ export abstract class Element extends HTMLElement {
     this._vroot = VirtualElement.createFor("<root>", this._root);
     this._vroot!.updateChildren(content);
 
-    this.lifecycle.dispatchEvent(new ElementDidMountEvent());
+    queueMicrotask(() => {
+      this.lifecycle.dispatchEvent(new ElementDidMountEvent());
+    });
   }
 
   private _updateDom(): void {
@@ -46,7 +67,9 @@ export abstract class Element extends HTMLElement {
       this._performFirstMount([json]);
     }
 
-    this.lifecycle.dispatchEvent(new ElementDidUpdateEvent());
+    queueMicrotask(() => {
+      this.lifecycle.dispatchEvent(new ElementDidUpdateEvent());
+    });
   }
 
   private _handleAttributeChange(mutationRecord: MutationRecord[]) {
@@ -91,6 +114,216 @@ export abstract class Element extends HTMLElement {
   public disconnectedCallback(): void {
     this._isConnected = false;
     this._attributeObserver.disconnect();
+  }
+
+  /**
+   * Registers a callback that will be ran on every change of the
+   * specified dependencies (attribute or state).
+   *
+   * This effect always happens after the DOM has been updated.
+   *
+   * @returns A `stop` function that cancels the effect.
+   */
+  public effect<E extends Element>(
+    this: E,
+    callback: Function,
+    getDependencies: (select: {
+      [K in keyof Omit<E, keyof Element | "render">]: Dependency<
+        E[K]
+      >;
+    }) => Dependency<any>[] | void,
+  ): () => void {
+    const deps = getDependencies(this._dependencySelector);
+
+    if (!deps) {
+      const updateHandler = () => callback;
+      this.lifecycle.on(
+        ElementLifecycleEvent.DidUpdate,
+        updateHandler,
+      );
+      return () => {
+        this.lifecycle.off(
+          ElementLifecycleEvent.DidUpdate,
+          updateHandler,
+        );
+      };
+    }
+
+    if (deps.length === 0) {
+      const updateHandler = () => callback;
+      this.lifecycle.once(
+        ElementLifecycleEvent.DidMount,
+        updateHandler,
+      );
+      return () => {
+        this.lifecycle.off(
+          ElementLifecycleEvent.DidMount,
+          updateHandler,
+        );
+      };
+    }
+
+    const depNamesForAttr = deps.map((d) => d.name.toLowerCase());
+    const depNamesForState = deps.map((d) => d.name);
+
+    let runCallbackOnNextUpdate = false;
+
+    const attribChangeHandler = (
+      ev: ElementAttributeDidChangeEvent,
+    ) => {
+      if (depNamesForAttr.includes(ev.detail.attributeName)) {
+        runCallbackOnNextUpdate = true;
+      }
+    };
+
+    const stateChangeHandler = (ev: ElementStateDidChangeEvent) => {
+      if (depNamesForState.includes(ev.detail.stateName)) {
+        runCallbackOnNextUpdate = true;
+      }
+    };
+
+    const didUpdateHandler = () => {
+      if (runCallbackOnNextUpdate) {
+        runCallbackOnNextUpdate = false;
+        callback();
+      }
+    };
+
+    this.lifecycle.on(
+      ElementLifecycleEvent.AttributeDidChange,
+      attribChangeHandler,
+    );
+    this.lifecycle.on(
+      ElementLifecycleEvent.StateDidChange,
+      stateChangeHandler,
+    );
+    this.lifecycle.on(
+      ElementLifecycleEvent.DidUpdate,
+      didUpdateHandler,
+    );
+
+    const stop = (): void => {
+      this.lifecycle.off(
+        ElementLifecycleEvent.AttributeDidChange,
+        attribChangeHandler,
+      );
+      this.lifecycle.off(
+        ElementLifecycleEvent.StateDidChange,
+        stateChangeHandler,
+      );
+      this.lifecycle.off(
+        ElementLifecycleEvent.DidUpdate,
+        didUpdateHandler,
+      );
+    };
+
+    return stop;
+  }
+
+  /**
+   * Registers a callback that will be ran on every change of the
+   * specified dependencies (attribute or state).
+   *
+   * This effect always happens right before the render, meaning that
+   * state and attribute changes within it will affect the subsequent
+   * render result and won't trigger another re-render.
+   *
+   * @returns A `stop` function that cancels the effect.
+   */
+  public immediateEffect<E extends Element>(
+    this: E,
+    callback: Function,
+    getDependencies: (select: {
+      [K in keyof Omit<E, keyof Element | "render">]: Dependency<
+        E[K]
+      >;
+    }) => Dependency<any>[] | void,
+  ): () => void {
+    const deps = getDependencies(this._dependencySelector);
+
+    if (!deps) {
+      const updateHandler = () => callback;
+      this.lifecycle.on(
+        ElementLifecycleEvent.WillUpdate,
+        updateHandler,
+      );
+      return () => {
+        this.lifecycle.off(
+          ElementLifecycleEvent.WillUpdate,
+          updateHandler,
+        );
+      };
+    }
+
+    if (deps.length === 0) {
+      const updateHandler = () => callback;
+      this.lifecycle.once(
+        ElementLifecycleEvent.DidMount,
+        updateHandler,
+      );
+      return () => {
+        this.lifecycle.off(
+          ElementLifecycleEvent.DidMount,
+          updateHandler,
+        );
+      };
+    }
+
+    const depNamesForAttr = deps.map((d) => d.name.toLowerCase());
+    const depNamesForState = deps.map((d) => d.name);
+
+    let runCallbackOnNextUpdate = false;
+
+    const attribChangeHandler = (
+      ev: ElementAttributeDidChangeEvent,
+    ) => {
+      if (depNamesForAttr.includes(ev.detail.attributeName)) {
+        runCallbackOnNextUpdate = true;
+      }
+    };
+
+    const stateChangeHandler = (ev: ElementStateDidChangeEvent) => {
+      if (depNamesForState.includes(ev.detail.stateName)) {
+        runCallbackOnNextUpdate = true;
+      }
+    };
+
+    const didUpdateHandler = () => {
+      if (runCallbackOnNextUpdate) {
+        runCallbackOnNextUpdate = false;
+        callback();
+      }
+    };
+
+    this.lifecycle.on(
+      ElementLifecycleEvent.AttributeDidChange,
+      attribChangeHandler,
+    );
+    this.lifecycle.on(
+      ElementLifecycleEvent.StateDidChange,
+      stateChangeHandler,
+    );
+    this.lifecycle.on(
+      ElementLifecycleEvent.WillUpdate,
+      didUpdateHandler,
+    );
+
+    const stop = (): void => {
+      this.lifecycle.off(
+        ElementLifecycleEvent.AttributeDidChange,
+        attribChangeHandler,
+      );
+      this.lifecycle.off(
+        ElementLifecycleEvent.StateDidChange,
+        stateChangeHandler,
+      );
+      this.lifecycle.off(
+        ElementLifecycleEvent.WillUpdate,
+        didUpdateHandler,
+      );
+    };
+
+    return stop;
   }
 
   protected abstract render(): JSX.Element;


### PR DESCRIPTION
Added two methods to the Element class that can be used by the extended component: `effect` and `immediateEffect`. These methods work similarly to the React's `useEffect` for those familiar with it. The callback given to those will run every time one of the effect dependencies changes, `effect` will do so after the render cycle, that was requested by the change of one of the dependencies, completes, while `immediateEffect` will run before the render cycle (`before update` event and `did update` events respsectively.

**Example**
```tsx
class MyComponent extends Element {
  @State()
  foo = 1;

  @Attribute()
  bar = "abc";

  constuctor() {
    super()

    this.effect(
      () => {/* do something */},
      (dependOn) => [dependOn.foo, dependOn.bar]
    )
  }

  render() {
    return <div>...</div>
  }
}
```